### PR TITLE
Add retry event

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ A queue object emits the following event:
 
 * `drain` — when there are no more jobs pending. Also happens on startup after consuming the backlog work units.
 * `error` - when something goes wrong.
+* `retry` - when a job is retried because something goes wrong.
 
 
 ## Client isolated API

--- a/server.js
+++ b/server.js
@@ -150,6 +150,7 @@ function flush(q) {
       errorBackoff.failAfter(q._options.maxRetries);
 
       errorBackoff.on('ready', function() {
+        q.emit('retry', err);
         run(q, JSON.parse(work), ranAgain);
       });
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -121,6 +121,25 @@ test('retries on error', function(t) {
   });
 });
 
+test('emits retry event on retry', function(t) {
+  rimraf.sync(dbPath);
+  var db = level(dbPath);
+  var queue = Jobs(db, worker);
+
+  queue.on('error', Function());
+
+  queue.once('retry', function(err) {
+    db.once('closed', t.end.bind(t));
+    db.close();
+  });
+
+  function worker(work, cb) {
+    cb(new Error('oops!'));
+  };
+
+  queue.push({ foo: 'bar' });
+});
+
 test('works with no push callback', function(t) {
   rimraf.sync(dbPath);
   var db = level(dbPath);


### PR DESCRIPTION
Fairly simple change; a `retry` event now gets emitted every time a job fails and is retried.