### PR TITLE
client: added pushBatch and delBatch functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ var jobId = queue.push(payload, function(err) {
 });
 ```
 
+or in batch:
+```javascript
+var payloads = [
+  {what: 'ever'},
+  {what: 'ever'}
+];
+
+var jobIds = queue.pushBatch(payloads, function(err) {
+  if (err) console.error('Error pushing works into the queue', err.stack);
+});
+```
+
 ### Delete pending job
 
 (Only works for jobs that haven't started yet!)
@@ -101,6 +113,13 @@ var jobId = queue.push(payload, function(err) {
 ```javascript
 queue.del(jobId, function(err) {
   if (err) console.error('Error deleting job', err.stack);
+});
+```
+
+or in batch:
+```javascript
+queue.delBatch(jobIds, function(err) {
+  if (err) console.error('Error deleting jobs', err.stack);
 });
 ```
 

--- a/client.js
+++ b/client.js
@@ -46,10 +46,47 @@ Q.push = function push(payload, cb) {
   };
 }
 
+/// pushBatch
+
+Q.pushBatch = function push(payloads, cb) {
+  var q = this;
+  var ids = [];
+
+  var ops = payloads.map(function(payload) {
+    var id = timestamp();
+    ids.push(id)
+    return {
+      type: 'put',
+      key: id,
+      value: stringify(payload)
+    }
+  })
+
+  this._work.batch(ops, batch);
+
+  return ids;
+
+  function batch(err) {
+    if (err) {
+      if (cb) cb(err);
+      else q.emit('error', err);
+    } else if (cb) cb();
+  };
+}
+
 /// del
 
 Q.del = function del(id, cb) {
   this._work.del(id, cb);
+}
+
+/// delBatch
+
+Q.delBatch = function del(ids, cb) {
+  var ops = ids.map(function(id) {
+    return { type: 'del', key: id }
+  })
+  this._work.batch(ops, cb);
 }
 
 Q.pendingStream = function pendingStream(options) {

--- a/tests/client.js
+++ b/tests/client.js
@@ -36,3 +36,39 @@ test('can insert and delete job', function(t) {
   var job2Id = clientQueue.push({ foo: 'bar', seq: 2 });
   t.type(job2Id, 'number');
 });
+
+test('can insert and delete jobs in batches', function(t) {
+  rimraf.sync(dbPath);
+  var db = level(dbPath);
+  var jobs = Jobs(db, worker);
+
+  var clientQueue = ClientJobs(db);
+  var processed = 0;
+
+  function worker (id, payload, done) {
+    processed += 1;
+    t.ok(processed <= 1, 'worker is not called 2 times');
+
+    var remainingJobsIds = jobBatchIds.slice(1)
+
+    clientQueue.delBatch(remainingJobsIds, function(err) {
+      if (err) throw err;
+      done();
+    });
+
+    setTimeout(function() {
+      db.once('closed', t.end.bind(t));
+      db.close();
+    }, 500);
+  };
+
+  var jobBatchIds = clientQueue.pushBatch([
+    { foo: 'bar', seq: 1 },
+    { foo: 'bar', seq: 2 },
+    { foo: 'bar', seq: 3 }
+  ]);
+
+  jobBatchIds.forEach(function(id) {
+    t.type(id, 'number');
+  })
+});


### PR DESCRIPTION
adds `pushBatch` and  `delBatch` functions to take advantage of [levelup `db.batch` function](https://github.com/Level/levelup#batch): both re-use their respective single work operation interfaces, with the only difference that `pushBatch` expects an array of `payload`s and `delBatch` expects an array of `jobId`s.