### PR TITLE
Get rid of unnecessary loop

### DIFF
--- a/timestamp.js
+++ b/timestamp.js
@@ -4,7 +4,7 @@ var lastTime;
 
 function timestamp() {
   var t = Date.now() * 1024 + Math.floor(Math.random() * 1024);
-  if (lastTime) while (t <= lastTime) t ++;
+  if (lastTime) t = lastTime + 1;
   lastTime = t;
   return t;
 }


### PR DESCRIPTION
This loop can cause increased CPU usage when the system time is changed far back (-1 year for example).